### PR TITLE
fix: drop support for Node v10

### DIFF
--- a/.github/workflows/build-and-test-and-deploy.yml
+++ b/.github/workflows/build-and-test-and-deploy.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 12
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release:major": "npm run release -- --release-as major"
   },
   "engines": {
-    "node": ">=10.13"
+    "node": "^14.18 || ^12 || ^16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Beware that Node v15 is explicitly not supported either while it has never been supported officially in the first run.**

BREAKING CHANGE: Node v10 is not supported anymore.